### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/src/main/java/org/springframework/cloud/stream/binder/gemfire/GemfireMessageChannelBinder.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/gemfire/GemfireMessageChannelBinder.java
@@ -50,7 +50,7 @@ import org.springframework.util.StringUtils;
 
 
 /**
- * A binder that uses <a href="http://gemfire.docs.pivotal.io/">GemFire</a>
+ * A binder that uses <a href="https://gemfire.docs.pivotal.io/">GemFire</a>
  * for message delivery. Spring Cloud Stream modules that are of type
  * processor or sink will host buckets for a partitioned region used
  * to store {@link Message messages}. This allows for message delivery

--- a/src/main/java/org/springframework/cloud/stream/binder/gemfire/config/GemfireProperties.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/gemfire/config/GemfireProperties.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.Min;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Gemfire <a href = "http://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">properties</a>
+ * Gemfire <a href = "https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html">properties</a>
  * in a JavaBean style object. This allows for the use of
  * <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html">Spring Boot</a>
  * configuration for Gemfire properties.
@@ -704,7 +704,7 @@ public class GemfireProperties {
 	 * systems that use unique addresses but the same port number.
 	 * <p>
 	 * This default multicast address was assigned by IANA
-	 * (http://www.iana.org/assignments/multicast-addresses). Consult the
+	 * (https://www.iana.org/assignments/multicast-addresses). Consult the
 	 * IANA chart when selecting another multicast address to use with GemFire.
 	 * <p>
 	 * Note: This setting controls only peer-to-peer communication and does


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://gemfire.docs.pivotal.io/ with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/ ([https](https://gemfire.docs.pivotal.io/) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/reference/topics/gemfire_properties.html) result 302).
* [ ] http://www.iana.org/assignments/multicast-addresses with 1 occurrences migrated to:  
  https://www.iana.org/assignments/multicast-addresses ([https](https://www.iana.org/assignments/multicast-addresses) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:%d/is-bound with 1 occurrences
* http://localhost:%d/message-payload with 1 occurrences
* http://localhost:%d/partition-strategy-invoked with 1 occurrences